### PR TITLE
Refresh traffic lights on window resize

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -131,6 +131,7 @@ export default class ElectronWindowTweaker extends Plugin {
         this.settings.trafficLightsPosX,
         this.settings.trafficLightsPosY
       );
+      window.onresize = (event) => {setTrafficLightsPos(this.styleTag, this.settings.trafficLightsPosX, this.settings.trafficLightsPosY)};
     }
 
     this.addCommand({


### PR DESCRIPTION
Added a line to refresh traffic light position whenever the window changes size. Specifically useful if you have the traffic lights set out of frame.